### PR TITLE
change scripts, install opencv with version 4.2.0.32

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This project currently works with Python 2.7 under linux.
 
     ```bash
     pip install future
-    pip install numpy h5py opencv-python-headless openxc==0.15.0
+    pip install numpy h5py opencv-python-headless==4.2.0.32 openxc==0.15.0
     ```
 
 3. There is no step 3, have fun! :tada:


### PR DESCRIPTION
`pip install opencv-python-headless` will cause an error: `TypeError: 'NoneType' object is not iterable`.
Because pip will download the latest opencv, while Python 2.7 is not supported anymore since 4.2.0.32.
See this [issue](https://github.com/skvark/opencv-python/issues/371#issuecomment-671292850).
And see this [Stackoverflow q-a](https://stackoverflow.com/questions/63346648/python-2-7-installing-opencv-via-pip-virtual-environment).